### PR TITLE
Point to helpers correctly

### DIFF
--- a/db/assignments/judge/BaseJudge.js
+++ b/db/assignments/judge/BaseJudge.js
@@ -1,5 +1,5 @@
 const util = require('util')
-const { isString } = require('../helpers.js')
+const { isString } = require('../../helpers.js')
 
 class BaseJudge {
   constructor (assignment, user) {


### PR DESCRIPTION
Relevant error before:

```
...
    throw err;
    ^

Error: Cannot find module '../helpers.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:611:15)
    at Function.Module._load (internal/modules/cjs/loader.js:537:25)
    at Module.require (internal/modules/cjs/loader.js:665:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/blabla/repositories/blockchain-course/db/assignments/judge/BaseJudge.js:2:22)
...
```